### PR TITLE
feat: add EXIF location support to image metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ type GyazoImage = {
     locale: string;
     description: string;
   };
+  exif_normalized?: {
+    latitude: number;
+    longitude: number;
+  };
 };
 
 /**
@@ -127,7 +131,12 @@ const getImageMetadataMarkdown = (gyazoImage: GyazoImage) => {
     imageMetadataMarkdown += `### OCR:\n${gyazoImage.ocr.description}\n\n`;
   }
   if (gyazoImage.ocr?.locale) {
-    imageMetadataMarkdown += `### Locale:\n${gyazoImage.ocr.locale}\n\n`;
+    imageMetadataMarkdown += `### OCR Locale:\n${gyazoImage.ocr.locale}\n\n`;
+  }
+  if (gyazoImage.exif_normalized) {
+    imageMetadataMarkdown += `### EXIF Location:\n`;
+    imageMetadataMarkdown += `Latitude: ${gyazoImage.exif_normalized.latitude}\n`;
+    imageMetadataMarkdown += `Longitude: ${gyazoImage.exif_normalized.longitude}\n\n`;
   }
   return imageMetadataMarkdown;
 };


### PR DESCRIPTION
This pull request includes changes to the `src/index.ts` file to enhance the metadata extraction and display functionality for Gyazo images. The most important changes include adding support for EXIF location data and improving the existing OCR locale metadata display.

Enhancements to metadata extraction and display:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R53-R56): Added an optional `exif_normalized` field to the `GyazoImage` type to store latitude and longitude data.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L130-R139): Modified the `getImageMetadataMarkdown` function to include EXIF location data in the metadata markdown output and improved the display of OCR locale metadata.