### PR TITLE
feat: Add glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "yuiseki"
+  ]
+}


### PR DESCRIPTION
This pull request adds a new configuration file, `glama.json`, to define schema and maintainers for the project.

Configuration updates:

* [`glama.json`](diffhunk://#diff-5c4858d944fd8fd55becb77ca5ece66ea44d617dcd7364cbfd663d80ddb0c6dcR1-R6): Introduced a new JSON configuration file specifying the schema URL (`https://glama.ai/mcp/schemas/server.json`) and listing "yuiseki" as the maintainer.


### Related

- https://github.com/nota/gyazo-mcp-server/issues/32