### PR TITLE
fix: Configure GitHub to recognize TypeScript as main language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Configure GitHub language statistics
+
+# Mark built JavaScript files as generated to exclude from language statistics
+build/**/*.js linguist-generated=true
+
+# Explicitly mark TypeScript as the main language
+*.ts linguist-detectable=true
+*.ts linguist-language=TypeScript


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to improve GitHub language statistics configuration. The changes ensure that built JavaScript files are excluded from language statistics and explicitly mark TypeScript as the main language.

GitHub language statistics configuration:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R8): Marked all built JavaScript files (`build/**/*.js`) as generated to exclude them from language statistics.
* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R8): Explicitly set TypeScript files (`*.ts`) as detectable and assigned the language as TypeScript.