### PR TITLE
fix: Remove console.log statements to ensure clean stdio communication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ server.setRequestHandler(callToolHandler.schema, callToolHandler.handler);
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log(`${SERVER_CONFIG.name} server started`);
 }
 
 main().catch((error) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,10 +87,6 @@ export async function compressImageIfNeeded(
     };
   }
 
-  console.log(
-    `Image size (${imageBuffer.length} bytes) exceeds maximum allowed size (${maxSizeBytes} bytes). Compressing...`
-  );
-
   // 初期の圧縮品質
   let quality = 90;
   let compressedBuffer: Buffer;
@@ -111,12 +107,6 @@ export async function compressImageIfNeeded(
       break;
     }
   } while (compressedBuffer.length > maxSizeBytes);
-
-  console.log(
-    `Compressed image to JPEG with quality ${quality + 10}%. New size: ${
-      compressedBuffer.length
-    } bytes`
-  );
 
   // Base64に変換
   const compressedBase64 = `data:image/jpeg;base64,${compressedBuffer.toString(


### PR DESCRIPTION
# Remove console.log statements to ensure clean stdio communication

## Why this change is necessary
This MCP (Model Context Protocol) server uses stdio transport to communicate with other processes. The presence of `console.log` statements in the codebase pollutes the stdout stream, which can interfere with the communication protocol and cause message corruption or misinterpretation.

## What was changed
- Removed `console.log` statements from `src/index.ts` (server startup message)
- Removed `console.log` statements from `src/utils.ts` (image compression debug information)
- Kept `console.error` for error handling as errors are sent to stderr, not stdout

## Expected benefits
- More reliable communication between processes
- Prevention of protocol interference
- Cleaner IPC (Inter-Process Communication) channel
- Maintains proper error logging via stderr

This change aligns with best practices for applications that use standard I/O streams as communication channels, ensuring the integrity of the MCP protocol implementation.