### PR TITLE
fix: gyazo_image tool not response current format

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -231,13 +231,13 @@ async function handleGyazoImage(request: any) {
   return {
     content: [
       {
+        type: "text",
+        text: imageMetadataMarkdown,
+      },
+      {
         type: "image",
         data: imageBase64,
         mimeType: mimeType,
-      },
-      {
-        type: "text",
-        text: imageMetadataMarkdown,
       },
     ],
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,7 @@ export async function compressImageIfNeeded(
   if (imageBuffer.length <= maxSizeBytes) {
     // サイズが制限内なら元のデータを返す
     return {
-      data: base64Data,
+      data: imageBuffer.toString("base64"),
       mimeType: originalMimeType,
     };
   }
@@ -109,9 +109,7 @@ export async function compressImageIfNeeded(
   } while (compressedBuffer.length > maxSizeBytes);
 
   // Base64に変換
-  const compressedBase64 = `data:image/jpeg;base64,${compressedBuffer.toString(
-    "base64"
-  )}`;
+  const compressedBase64 = `${compressedBuffer.toString("base64")}`;
 
   return {
     data: compressedBase64,


### PR DESCRIPTION
This pull request includes changes to improve the handling of image data and metadata in the `src/handlers/tools.ts` and `src/utils.ts` files. The most important updates involve reordering content types in the `handleGyazoImage` function and refining how image buffers are converted to Base64 strings in the `compressImageIfNeeded` utility function.

### Changes to image data handling:

* [`src/handlers/tools.ts`](diffhunk://#diff-0a21cae5dda277fb047608a009d13e14701c97206166b1cb9cb2aa766848df25R233-L241): Reordered the content types in the `handleGyazoImage` function to place the text metadata before the image data in the returned content array.

### Changes to Base64 encoding:

* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L85-R85): Updated the `compressImageIfNeeded` function to directly convert the `imageBuffer` to a Base64 string using `toString("base64")` instead of relying on a pre-encoded variable. This ensures consistency and removes unnecessary string concatenation. [[1]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L85-R85) [[2]](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L112-R112)