### PR TITLE
chore: Update description of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gyazo-mcp-server",
   "version": "0.1.0",
-  "description": "A MCP server for Gyazo",
+  "description": "Official Model Context Protocol server for Gyazo",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file to clarify the project description.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the `description` field to specify that this is the "Official Model Context Protocol server for Gyazo" instead of the previous "A MCP server for Gyazo."