### PR TITLE
Release v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,39 +25,31 @@ This is a TypeScript-based MCP server that provides access to Gyazo images. It a
   - Returns both image content and metadata
   - Includes OCR text if available
 
-## Development
-
-Install dependencies:
-
-```bash
-npm ci
-```
-
-Build the server:
-
-```bash
-npm run build
-```
-
-For development with auto-rebuild:
-
-```bash
-npm run watch
-```
-
-### Docker
-
-```bash
-npm run image:build
-```
-
 ## Installation
+
+### NPM Package
+
+The easiest way to install the Gyazo MCP server is via npm:
+
+```bash
+npm install -g @notainc/gyazo-mcp-server
+```
 
 ### Prerequisites
 
-1. Create a Gyazo account if you don't have one: https://gyazo.com
-2. Get your Gyazo API access token from: https://gyazo.com/api
-3. Set the `GYAZO_ACCESS_TOKEN` environment variable with your token
+- Create a Gyazo account if you don't have one: https://gyazo.com
+- Get your Gyazo API access token from: https://gyazo.com/api
+  - Click "Register applications" button
+  - Click "New Application" button
+  - Fill in the form with your app name and description
+    - Name and Callback URL are required
+    - You can use `http://localhost` for the Callback URL
+  - Click "Submit" button
+  - Click application name to view details
+  - Scroll down to "Your Access Token"
+  - Click "Generate" button
+  - Copy "Your access token" value
+- Set the `GYAZO_ACCESS_TOKEN` environment variable with your token
 
 ### Claude Desktop Integration
 
@@ -66,11 +58,14 @@ To use with Claude Desktop, add the server config:
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
+#### Using NPM package (recommended)
+
 ```json
 {
   "mcpServers": {
     "gyazo-mcp-server": {
-      "command": "/path/to/gyazo-mcp-server/build/index.js",
+      "command": "npx",
+      "args": ["@notainc/gyazo-mcp-server"],
       "env": {
         "GYAZO_ACCESS_TOKEN": "your-access-token-here"
       }
@@ -79,7 +74,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 }
 ```
 
-#### Docker
+#### Using Docker (optional)
 
 ```json
 {
@@ -102,15 +97,31 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 }
 ```
 
-### Debugging
+## Development
 
-Since MCP servers communicate over stdio, debugging can be challenging. We recommend using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), which is available as a package script:
+Install dependencies:
 
 ```bash
-npm run inspector
+npm ci
 ```
 
-The Inspector will provide a URL to access debugging tools in your browser.
+Build the server:
+
+```bash
+npm run build
+```
+
+For development with auto-rebuild:
+
+```bash
+npm run watch
+```
+
+### Docker Build (optional)
+
+```bash
+npm run image:build
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "gyazo-mcp-server",
+  "name": "@notainc/gyazo-mcp-server",
   "version": "0.1.0",
   "description": "Official Model Context Protocol server for Gyazo",
-  "private": true,
   "type": "module",
   "bin": {
     "gyazo-mcp-server": "./build/index.js"


### PR DESCRIPTION
# Prepare v0.1.0 release with npm package configuration

## Overview
This PR prepares the Gyazo Model Context Protocol (MCP) server for its first public release as version 0.1.0. The changes focus on making the package ready for npm publication and improving documentation for users.

## Changes
- Updated package name from `gyazo-mcp-server` to `@notainc/gyazo-mcp-server` for npm publishing under Nota Inc. organization
- Removed the `private` flag in package.json to enable npm publishing
- Enhanced README with detailed installation instructions and usage examples
- Finalized configuration for v0.1.0 release

## Testing
- Verified package builds correctly
- Tested installation process following the updated README instructions
- Confirmed all functionality works as expected

## Release Plan
After merging this PR, we will:
1. Tag the repository with v0.1.0
2. Publish the package to npm registry
3. Announce the release to relevant stakeholders

This marks our first official release of the Gyazo MCP server, making it easier for developers to integrate Gyazo's context functionality into their applications.