### PR TITLE
feat: add proxy for native Gyazo MCP server tools

### DIFF
--- a/src/capture-proxy.ts
+++ b/src/capture-proxy.ts
@@ -1,0 +1,287 @@
+/**
+ * Module for interfacing with native Gyazo MCPServer (Windows/macOS)
+ */
+import { spawn, ChildProcess } from "child_process";
+import { existsSync } from "fs";
+import { platform } from "os";
+import { join } from "path";
+
+// Path constants
+const WIN_GYAZO_MCP_SERVER_PATH =
+  "C:\\Program Files (x86)\\Gyazo\\GyazoWinMCPServer.exe";
+const MAC_GYAZO_MCP_SERVER_PATH =
+  "/Applications/Gyazo Menu.app/Contents/Helpers/cli-tool/GyazoMacMCPServer";
+
+// Type definitions
+export type MCPRequest = {
+  method: string;
+  params: any;
+};
+
+export type MCPResponse = {
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+// Class to manage native MCP server process
+export class GyazoNativeMCPServer {
+  private static instance: GyazoNativeMCPServer | null = null;
+  private childProcess: ChildProcess | null = null;
+  private pendingRequests: Map<
+    string,
+    { resolve: Function; reject: Function }
+  > = new Map();
+  private requestCounter = 0;
+  private buffers: string[] = [];
+  private _isAvailable: boolean = false;
+
+  private constructor() {}
+
+  // Singleton pattern
+  public static getInstance(): GyazoNativeMCPServer {
+    if (!GyazoNativeMCPServer.instance) {
+      GyazoNativeMCPServer.instance = new GyazoNativeMCPServer();
+    }
+    return GyazoNativeMCPServer.instance;
+  }
+
+  // Check if native MCP server is available
+  public get isAvailable(): boolean {
+    return this._isAvailable;
+  }
+
+  // Initialize and connect to the native MCP server
+  public async initialize(): Promise<boolean> {
+    const serverPath = this.getServerPath();
+
+    if (!serverPath) {
+      this._isAvailable = false;
+      return false;
+    }
+
+    try {
+      // Start the child process
+      this.childProcess = spawn(serverPath, [], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Set up event listeners
+      this.childProcess.stdout?.on("data", (data: Buffer) => {
+        const messages = data.toString().split("\n");
+
+        for (let i = 0; i < messages.length; i++) {
+          const message = messages[i];
+          if (!message.trim()) continue;
+
+          // Last message might be incomplete
+          if (i === messages.length - 1 && !message.endsWith("}")) {
+            this.buffers.push(message);
+            continue;
+          }
+
+          // If we have buffered data, combine it with the current message
+          if (this.buffers.length > 0) {
+            this.buffers.push(message);
+            const completeMessage = this.buffers.join("");
+            this.buffers = [];
+            this.handleResponse(completeMessage);
+          } else {
+            this.handleResponse(message);
+          }
+        }
+      });
+
+      this.childProcess.stderr?.on("data", (data: Buffer) => {
+        // stdioを汚染しないよう、標準出力にはログを出力しない
+      });
+
+      this.childProcess.on("close", (code: number) => {
+        // stdioを汚染しないよう、標準出力にはログを出力しない
+        this.childProcess = null;
+        this._isAvailable = false;
+      });
+
+      // Ping the server to ensure it's working
+      await this.sendRequest({
+        method: "mcp.listTools",
+        params: {},
+      });
+
+      this._isAvailable = true;
+      return true;
+    } catch (error) {
+      // stdioを汚染しないよう、標準出力にはログを出力しない
+      this._isAvailable = false;
+      return false;
+    }
+  }
+
+  // Send a request to the native MCP server
+  public async sendRequest(request: MCPRequest): Promise<any> {
+    if (!this.childProcess || !this.isAvailable) {
+      throw new Error("Native MCP server is not available");
+    }
+
+    return new Promise((resolve, reject) => {
+      const id = (this.requestCounter++).toString();
+      const jsonRpcRequest = {
+        jsonrpc: "2.0",
+        id,
+        method: request.method,
+        params: request.params,
+      };
+
+      this.pendingRequests.set(id, { resolve, reject });
+
+      const requestString = JSON.stringify(jsonRpcRequest) + "\n";
+      this.childProcess?.stdin?.write(requestString);
+    });
+  }
+
+  // Handle response from the native MCP server
+  private handleResponse(data: string): void {
+    try {
+      const response = JSON.parse(data);
+      const id = response.id as string;
+      const pendingRequest = this.pendingRequests.get(id);
+
+      if (pendingRequest) {
+        if (response.error) {
+          pendingRequest.reject(new Error(response.error.message));
+        } else {
+          pendingRequest.resolve(response.result);
+        }
+        this.pendingRequests.delete(id);
+      }
+    } catch (error) {
+      // stdioを汚染しないよう、標準出力にはログを出力しない
+    }
+  }
+
+  // Get the path to the native MCP server based on OS
+  private getServerPath(): string | null {
+    const os = platform();
+
+    if (os === "win32") {
+      return existsSync(WIN_GYAZO_MCP_SERVER_PATH)
+        ? WIN_GYAZO_MCP_SERVER_PATH
+        : null;
+    } else if (os === "darwin") {
+      return existsSync(MAC_GYAZO_MCP_SERVER_PATH)
+        ? MAC_GYAZO_MCP_SERVER_PATH
+        : null;
+    }
+
+    return null;
+  }
+
+  // Clean up resources when shutting down
+  public cleanup(): void {
+    if (this.childProcess) {
+      this.childProcess.kill();
+      this.childProcess = null;
+    }
+    this._isAvailable = false;
+  }
+}
+
+// Exported functions for use in the MCP server
+
+/**
+ * Check if native capture tools are available
+ */
+export async function checkNativeCaptureAvailability(): Promise<boolean> {
+  const server = GyazoNativeMCPServer.getInstance();
+
+  if (!server.isAvailable) {
+    try {
+      return await server.initialize();
+    } catch (error) {
+      // stdioを汚染しないよう、標準出力にはログを出力しない
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * List capturable windows
+ */
+export async function listCapturableWindows(limit: number = 30): Promise<any> {
+  const server = GyazoNativeMCPServer.getInstance();
+
+  if (!server.isAvailable) {
+    throw new Error("Native capture server is not available");
+  }
+
+  return await server.sendRequest({
+    method: "mcp.callTool",
+    params: {
+      name: "list_capturable_windows",
+      arguments: { limit },
+    },
+  });
+}
+
+/**
+ * Capture and upload primary screen
+ */
+export async function captureAndUploadPrimaryScreen(): Promise<any> {
+  const server = GyazoNativeMCPServer.getInstance();
+
+  if (!server.isAvailable) {
+    throw new Error("Native capture server is not available");
+  }
+
+  return await server.sendRequest({
+    method: "mcp.callTool",
+    params: {
+      name: "capture_and_upload_primary_screen",
+      arguments: {},
+    },
+  });
+}
+
+/**
+ * Capture and upload selected region
+ */
+export async function captureAndUploadRegion(): Promise<any> {
+  const server = GyazoNativeMCPServer.getInstance();
+
+  if (!server.isAvailable) {
+    throw new Error("Native capture server is not available");
+  }
+
+  return await server.sendRequest({
+    method: "mcp.callTool",
+    params: {
+      name: "capture_and_upload_region",
+      arguments: {},
+    },
+  });
+}
+
+/**
+ * Capture and upload window
+ */
+export async function captureAndUploadWindow(
+  windowHandle: string
+): Promise<any> {
+  const server = GyazoNativeMCPServer.getInstance();
+
+  if (!server.isAvailable) {
+    throw new Error("Native capture server is not available");
+  }
+
+  return await server.sendRequest({
+    method: "mcp.callTool",
+    params: {
+      name: "capture_and_upload_window",
+      arguments: { windowHandle },
+    },
+  });
+}

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -8,6 +8,13 @@ import {
 import * as api from "../api.js";
 import { getImageMetadataMarkdown } from "../utils.js";
 import { createImageUri } from "../utils.js";
+import {
+  checkNativeCaptureAvailability,
+  listCapturableWindows,
+  captureAndUploadPrimaryScreen,
+  captureAndUploadRegion,
+  captureAndUploadWindow,
+} from "../capture-proxy.js";
 
 /**
  * Handler for listing available tools
@@ -15,97 +22,162 @@ import { createImageUri } from "../utils.js";
 export const listToolsHandler = {
   schema: ListToolsRequestSchema,
   handler: async () => {
+    // Standard tools available in all platforms
+    const standardTools = [
+      {
+        name: "gyazo_search",
+        description: "Full-text search for captures uploaded by users on Gyazo",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description:
+                "Search keyword (max length: 200 characters). example: 'cat', 'title:cat', 'app:\"Google Chrome\"', 'url:google.com', 'cat since:2024-01-01 until:2024-12-31' NOTE: If you cannot find an appropriate capture, try rephrasing the search query to capture the user's intent and repeat the search several times",
+            },
+            page: {
+              type: "integer",
+              description: "Page number for pagination",
+              minimum: 1,
+              default: 1,
+            },
+            per: {
+              type: "integer",
+              description: "Number of results per page (max: 100)",
+              minimum: 1,
+              maximum: 100,
+              default: 20,
+            },
+          },
+          required: ["query"],
+        },
+      },
+      {
+        name: "gyazo_image",
+        description: "Fetch image content and metadata from Gyazo",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id_or_url: {
+              type: "string",
+              description: "ID or URL of the image on Gyazo",
+            },
+          },
+          required: ["id_or_url"],
+        },
+      },
+      {
+        name: "gyazo_latest_image",
+        description:
+          "Fetch latest uploaded image content and metadata from Gyazo",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              const: "gyazo_latest_image",
+            },
+          },
+          required: ["name"],
+        },
+      },
+      {
+        name: "gyazo_upload",
+        description: "Upload an image to Gyazo",
+        inputSchema: {
+          type: "object",
+          properties: {
+            imageData: {
+              type: "string",
+              description: "Base64 encoded image data",
+            },
+            title: {
+              type: "string",
+              description: "Title for the image (optional)",
+            },
+            description: {
+              type: "string",
+              description: "Description for the image (optional)",
+            },
+            refererUrl: {
+              type: "string",
+              description: "Source URL for the image (optional).",
+            },
+            app: {
+              type: "string",
+              description: "Application name for the image (optional).",
+            },
+          },
+          required: ["imageData"],
+        },
+      },
+    ];
+
+    // Check if native capture tools are available
+    const isCaptureAvailable = await checkNativeCaptureAvailability();
+
+    // Native capture tools available only in Windows/macOS with Gyazo installed
+    const captureTools = isCaptureAvailable
+      ? [
+          {
+            name: "gyazo_capture_and_upload_region",
+            description:
+              "Initiates a UI for region selection. Captures the selected screen area, uploads it to Gyazo, and returns the Gyazo image URL and image data.",
+            inputSchema: {
+              type: "object",
+              properties: {},
+              title: "capture_and_upload_region",
+            },
+          },
+          {
+            name: "gyazo_capture_and_upload_primary_screen",
+            description:
+              "Captures the entire primary screen, uploads it to Gyazo, and returns both the Gyazo image URL and image data.",
+            inputSchema: {
+              type: "object",
+              properties: {},
+              title: "capture_and_upload_primary_screen",
+            },
+          },
+          {
+            name: "gyazo_capture_and_upload_window",
+            description:
+              "Captures the specified window, uploads it to Gyazo, and returns both the Gyazo image URL and image data.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                windowHandle: {
+                  type: "string",
+                  description:
+                    "Hexadecimal string of the window handle to capture. Use the value obtained from calling list_capturable_windows.",
+                },
+              },
+              required: ["windowHandle"],
+              title: "capture_and_upload_window",
+            },
+          },
+          {
+            name: "gyazo_list_capturable_windows",
+            description:
+              "Returns a list of windows available for screen capture.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                limit: {
+                  type: "integer",
+                  description:
+                    "Maximum number of windows to retrieve. (Default value: 30)",
+                },
+              },
+              required: ["limit"],
+              title: "list_capturable_windows",
+            },
+          },
+        ]
+      : [];
+
     return {
-      tools: [
-        {
-          name: "gyazo_search",
-          description:
-            "Full-text search for captures uploaded by users on Gyazo",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: {
-                type: "string",
-                description:
-                  "Search keyword (max length: 200 characters). example: 'cat', 'title:cat', 'app:\"Google Chrome\"', 'url:google.com', 'cat since:2024-01-01 until:2024-12-31' NOTE: If you cannot find an appropriate capture, try rephrasing the search query to capture the user's intent and repeat the search several times",
-              },
-              page: {
-                type: "integer",
-                description: "Page number for pagination",
-                minimum: 1,
-                default: 1,
-              },
-              per: {
-                type: "integer",
-                description: "Number of results per page (max: 100)",
-                minimum: 1,
-                maximum: 100,
-                default: 20,
-              },
-            },
-            required: ["query"],
-          },
-        },
-        {
-          name: "gyazo_image",
-          description: "Fetch image content and metadata from Gyazo",
-          inputSchema: {
-            type: "object",
-            properties: {
-              id_or_url: {
-                type: "string",
-                description: "ID or URL of the image on Gyazo",
-              },
-            },
-            required: ["id_or_url"],
-          },
-        },
-        {
-          name: "gyazo_latest_image",
-          description:
-            "Fetch latest uploaded image content and metadata from Gyazo",
-          inputSchema: {
-            type: "object",
-            properties: {
-              name: {
-                type: "string",
-                const: "gyazo_latest_image",
-              },
-            },
-            required: ["name"],
-          },
-        },
-        {
-          name: "gyazo_upload",
-          description: "Upload an image to Gyazo",
-          inputSchema: {
-            type: "object",
-            properties: {
-              imageData: {
-                type: "string",
-                description: "Base64 encoded image data",
-              },
-              title: {
-                type: "string",
-                description: "Title for the image (optional)",
-              },
-              description: {
-                type: "string",
-                description: "Description for the image (optional)",
-              },
-              refererUrl: {
-                type: "string",
-                description: "Source URL for the image (optional).",
-              },
-              app: {
-                type: "string",
-                description: "Application name for the image (optional).",
-              },
-            },
-            required: ["imageData"],
-          },
-        },
-      ],
+      tools: [...standardTools, ...captureTools],
     };
   },
 };
@@ -126,11 +198,19 @@ export const callToolHandler = {
           return await handleGyazoLatestImage();
         case "gyazo_upload":
           return await handleGyazoUpload(request);
+        case "gyazo_list_capturable_windows":
+          return await handleListCapturableWindows(request);
+        case "gyazo_capture_and_upload_primary_screen":
+          return await handleCaptureAndUploadPrimaryScreen();
+        case "gyazo_capture_and_upload_region":
+          return await handleCaptureAndUploadRegion();
+        case "gyazo_capture_and_upload_window":
+          return await handleCaptureAndUploadWindow(request);
         default:
           throw new Error(`Tool ${request.params.name} not found`);
       }
     } catch (error) {
-      console.error(`Error calling tool ${request.params.name}:`, error);
+      // stdioを汚染しないため、エラーをそのままスローする
       if (error instanceof Error) {
         throw new Error(`Tool execution failed: ${error.message}`);
       } else {
@@ -301,6 +381,141 @@ async function handleGyazoUpload(request: any) {
       {
         type: "text",
         text: `Image successfully uploaded to Gyazo!\n\nPermalink URL: ${result.permalink_url}\nImage URL: ${result.url}\nImage ID: ${result.image_id}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Handler for gyazo_list_capturable_windows tool
+ */
+async function handleListCapturableWindows(request: any) {
+  // Check native capture availability
+  if (!(await checkNativeCaptureAvailability())) {
+    throw new Error("Native capture functionality is not available");
+  }
+
+  // Extract limit parameter or use default
+  const limit =
+    request.params.arguments &&
+    typeof request.params.arguments.limit === "number"
+      ? request.params.arguments.limit
+      : 30;
+
+  // Get windows list from native MCP server
+  const result = await listCapturableWindows(limit);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Handler for gyazo_capture_and_upload_primary_screen tool
+ */
+async function handleCaptureAndUploadPrimaryScreen() {
+  // Check native capture availability
+  if (!(await checkNativeCaptureAvailability())) {
+    throw new Error("Native capture functionality is not available");
+  }
+
+  // Capture screen and get result from native MCP server
+  const result = await captureAndUploadPrimaryScreen();
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Screen successfully captured and uploaded to Gyazo!\n\nPermalink URL: ${result.permalink_url}\nImage URL: ${result.url}`,
+      },
+      {
+        type: "image",
+        data: result.data,
+        mimeType: result.mimeType,
+      },
+    ],
+  };
+}
+
+/**
+ * Handler for gyazo_capture_and_upload_region tool
+ */
+async function handleCaptureAndUploadRegion() {
+  // Check native capture availability
+  if (!(await checkNativeCaptureAvailability())) {
+    throw new Error("Native capture functionality is not available");
+  }
+
+  try {
+    // Capture region and get result from native MCP server
+    const result = await captureAndUploadRegion();
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Region successfully captured and uploaded to Gyazo!\n\nPermalink URL: ${result.permalink_url}\nImage URL: ${result.url}`,
+        },
+        {
+          type: "image",
+          data: result.data,
+          mimeType: result.mimeType,
+        },
+      ],
+    };
+  } catch (error) {
+    // 領域選択がキャンセルされた場合などの特別なエラーハンドリング
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Could not capture the region. This may have happened because no region was selected.",
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Handler for gyazo_capture_and_upload_window tool
+ */
+async function handleCaptureAndUploadWindow(request: any) {
+  // Check native capture availability
+  if (!(await checkNativeCaptureAvailability())) {
+    throw new Error("Native capture functionality is not available");
+  }
+
+  // Validate window handle parameter
+  if (
+    !request.params.arguments ||
+    typeof request.params.arguments.windowHandle !== "string"
+  ) {
+    throw new Error(
+      "Invalid arguments: windowHandle is required and must be a string"
+    );
+  }
+
+  // Capture window and get result from native MCP server
+  const result = await captureAndUploadWindow(
+    request.params.arguments.windowHandle
+  );
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Window successfully captured and uploaded to Gyazo!\n\nPermalink URL: ${result.permalink_url}\nImage URL: ${result.url}`,
+      },
+      {
+        type: "image",
+        data: result.data,
+        mimeType: result.mimeType,
       },
     ],
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,25 @@ export type GyazoUploadResponse = {
   url: string;
   thumb_url?: string;
 };
+
+/**
+ * Type definition for capturable window
+ */
+export type CapturableWindow = {
+  handle: string;
+  title: string;
+  processName: string;
+  isVisible: boolean;
+  zOrder: number;
+};
+
+/**
+ * Type definition for capture and upload response
+ */
+export type CaptureUploadResponse = {
+  image_id: string;
+  permalink_url: string;
+  url: string;
+  data: string; // Base64 image data
+  mimeType: string;
+};


### PR DESCRIPTION
This pull request introduces native screen capture and upload functionality for Gyazo on Windows and macOS, integrating it into the existing toolset. The changes include a new module for managing the native MCP server, updates to the tool handlers to support capture-related operations, and enhancements to ensure graceful shutdown of resources.

### New Native Capture Integration

* **New `GyazoNativeMCPServer` class**: Added a singleton class in `src/capture-proxy.ts` to manage the lifecycle of the native MCP server, including initialization, request handling, and cleanup. It supports operations such as listing capturable windows, capturing the primary screen, capturing a selected region, and capturing a specific window.

### Tool Handler Updates

* **Tool registration and availability checks**: Updated the `listToolsHandler` in `src/handlers/tools.ts` to dynamically include native capture tools if the MCP server is available. These tools allow users to perform screen capture operations and upload results to Gyazo. [[1]](diffhunk://#diff-0a21cae5dda277fb047608a009d13e14701c97206166b1cb9cb2aa766848df25R11-R29) [[2]](diffhunk://#diff-0a21cae5dda277fb047608a009d13e14701c97206166b1cb9cb2aa766848df25L108-R180)
* **New tool handlers**: Added handlers for native capture tools (`gyazo_list_capturable_windows`, `gyazo_capture_and_upload_primary_screen`, `gyazo_capture_and_upload_region`, and `gyazo_capture_and_upload_window`) to process requests and interact with the MCP server. [[1]](diffhunk://#diff-0a21cae5dda277fb047608a009d13e14701c97206166b1cb9cb2aa766848df25R201-R213) [[2]](diffhunk://#diff-0a21cae5dda277fb047608a009d13e14701c97206166b1cb9cb2aa766848df25R388-R522)

### Graceful Shutdown Enhancements

* **Cleanup handlers**: Added cleanup logic in `src/index.ts` to ensure the MCP server is properly shut down during application termination (e.g., on `SIGINT`, `SIGTERM`, or process exit).

### Type Definitions

* **New types for capture operations**: Defined `CapturableWindow` and `CaptureUploadResponse` types in `src/types.ts` to standardize data structures for capturable windows and capture responses.