### PR TITLE
fix: return raw base64 data instead of data URI from fetchImageAsBase64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/api.ts
+++ b/src/api.ts
@@ -84,7 +84,7 @@ export async function fetchImageAsBase64(
   }
 
   return {
-    data: `data:${contentType};base64,${base64Data}`,
+    data: base64Data,
     mimeType: contentType,
   };
 }


### PR DESCRIPTION
## Summary
- `fetchImageAsBase64` が `data:${contentType};base64,...` 形式の data URI を返していたのを、生の base64 文字列を返すように修正
- MCP SDK はツール結果（`type: "image"`）とリソース応答（`blob` フィールド）の両方で、data URI ではなく生の base64 文字列を期待しているため、画像が正しく扱われていなかった

## Test plan
- [ ] `gyazo_image` ツールで画像が正しく表示されることを確認
- [ ] `gyazo_latest_image` ツールで画像が正しく表示されることを確認
- [ ] リソース経由での画像取得が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)