### PR TITLE
fix: make metadata fields optional to handle missing API responses

### DIFF
--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -21,7 +21,7 @@ export const listResourcesHandler = {
         resources: gyazoImages.map((gyazoImage) => ({
           uri: `gyazo-mcp:///${gyazoImage.image_id}`,
           mimeType: `image/${gyazoImage.type}`,
-          name: gyazoImage.metadata.title || gyazoImage.image_id,
+          name: gyazoImage.metadata?.title || gyazoImage.image_id,
         })),
       };
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,11 @@ export type GyazoImage = {
   url: string;
   type: string;
   created_at: string;
-  metadata: {
-    app: string;
-    title: string;
-    url: string;
-    desc: string;
+  metadata?: {
+    app?: string | null;
+    title?: string | null;
+    url?: string | null;
+    desc?: string | null;
   };
   ocr?: {
     locale: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,16 +9,16 @@ import { GyazoImage } from "./types.js";
  */
 export function getImageMetadataMarkdown(gyazoImage: GyazoImage): string {
   let imageMetadataMarkdown = "";
-  if (gyazoImage.metadata.title) {
+  if (gyazoImage.metadata?.title) {
     imageMetadataMarkdown += `### Title:\n${gyazoImage.metadata.title}\n\n`;
   }
-  if (gyazoImage.metadata.desc) {
+  if (gyazoImage.metadata?.desc) {
     imageMetadataMarkdown += `### Description:\n${gyazoImage.metadata.desc}\n\n`;
   }
-  if (gyazoImage.metadata.app) {
+  if (gyazoImage.metadata?.app) {
     imageMetadataMarkdown += `### App:\n${gyazoImage.metadata.app}\n\n`;
   }
-  if (gyazoImage.metadata.url) {
+  if (gyazoImage.metadata?.url) {
     imageMetadataMarkdown += `### URL:\n${gyazoImage.metadata.url}\n\n`;
   }
   if (gyazoImage.ocr?.description) {


### PR DESCRIPTION
## Summary
- `GyazoImage` 型の `metadata` とその各フィールド（`app`, `title`, `url`, `desc`）を optional + null 許容に変更
- `metadata` にアクセスする箇所でオプショナルチェーン (`?.`) を追加し、`metadata` が存在しない画像でのランタイムエラーを防止

## Test plan
- [ ] `metadata` が存在しない画像でリソース一覧取得がエラーにならないことを確認
- [ ] `metadata` が存在しない画像でメタデータ Markdown 生成がエラーにならないことを確認
- [ ] `metadata` が存在する画像で従来通り正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)