### PR TITLE
chore: pin GitHub Actions to commit hashes with pinact

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,21 @@
+name: Check Pinned Actions
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "main"
+
+jobs:
+  check-pinned-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - name: Check GitHub Actions are pinned to commit hashes
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+          verify: "true"

--- a/.github/workflows/publish_npm_package.yaml
+++ b/.github/workflows/publish_npm_package.yaml
@@ -11,8 +11,8 @@ jobs:
     name: 'Publish npm package'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           tag_name: 'v%s'
           node-version: '22.x'


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions versions to commit hashes using pinact for supply chain security
- Add `.github/workflows/pinact.yml` to continuously verify actions are pinned on every PR and push to `main`

## Changes

- `.github/workflows/lint.yaml`: `actions/checkout@v5` → `@93cb6efe...`, `actions/setup-node@v6` → `@48b55a01...`
- `.github/workflows/publish_npm_package.yaml`: same pinning as above
- `.github/workflows/pinact.yml`: new workflow using `suzuki-shunsuke/pinact-action@896d595f...` (v3.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)